### PR TITLE
Audio Functionality Extended

### DIFF
--- a/mge/src/mge/MGEMartijn.cpp
+++ b/mge/src/mge/MGEMartijn.cpp
@@ -17,7 +17,6 @@ extern "C" {
 
 #include "Audio.hpp"
 
-
 using namespace std;
 
 //construct the game class into _window, _renderer and hud (other parts are initialized by build)
@@ -45,6 +44,7 @@ void MGEMartijn::_initializeScene()
     Audio::StopSound("gate.wav");
     Audio::PlayMusic("memory.ogg");
     Audio::StopMusic("memory666.ogg");
+    Audio::PauseMusic("memory.ogg");
     // ==== end AUDIO test =====
 
 }

--- a/mge/src/mge/core/Audio.cpp
+++ b/mge/src/mge/core/Audio.cpp
@@ -72,7 +72,7 @@ void Audio::StopSound(std::string fileName) {
     instance = Instance();
 
     if(instance->Sounds.find(fileName) == instance->Sounds.end()) {
-        std::cout << "NOTE: Could not stop sound '" << fileName << "'." << std::endl;
+        std::cout << "ERROR: Could not stop sound '" << fileName << "'." << std::endl;
         return;
     }
 
@@ -91,19 +91,30 @@ void Audio::PlayMusic(std::string fileName, bool loop) {
 
     instance->GetMusic(fileName).setLoop(loop);
     instance->GetMusic(fileName).play();                                                        // Play music.
-    std::cout << "NOTE: Playing music '" << fileName << "'." << std::endl;
+    std::cout << "NOTE: Playing/Resuming music '" << fileName << "'." << std::endl;
 }
 
 // StopMusic cares about if a music is indexed! Not whether its playing or not.
 void Audio::StopMusic(std::string fileName) {
     instance = Instance();
     if(instance->Music.find(fileName) == instance->Music.end()) {
-        std::cout << "NOTE: Could not stop music '" << fileName << "'." << std::endl;
+        std::cout << "ERROR: Could not stop music '" << fileName << "'." << std::endl;
         return;
     }
 
     instance->GetMusic(fileName).stop();
     std::cout << "NOTE: Stopped music '" << fileName << "'." << std::endl;
+}
+
+void Audio::PauseMusic(std::string fileName) {
+    instance = Instance();
+    if(instance->Music.find(fileName) == instance->Music.end()) {
+        std::cout << "ERROR: Could not pause music '" << fileName << "'." << std::endl;
+        return;
+    }
+
+    instance->GetMusic(fileName).pause();
+    std::cout << "NOTE: Paused music '" << fileName << "'." << std::endl;
 }
 
 void Audio::AddMusic(std::string fileName) {

--- a/mge/src/mge/core/Audio.hpp
+++ b/mge/src/mge/core/Audio.hpp
@@ -22,11 +22,11 @@ class Audio
         sf::Sound &GetSound(std::string fileName);                      //Use getSound("...").play() to play
 
         static void PreloadAudio();
-        static void PlaySound(std::string fileName);
-        static void StopSound(std::string fileName);
-        static void PlayMusic(std::string fileName, bool loop = true);
-        static void StopMusic(std::string fileName);
-
+        static void PlaySound (std::string fileName);
+        static void StopSound (std::string fileName);
+        static void PlayMusic (std::string fileName, bool loop = true);
+        static void StopMusic (std::string fileName);
+        static void PauseMusic(std::string filename);
         void AddMusic(std::string fileName);                            //Indexes a specific music (used in LoadAudio())
         void MapMusic(std::string, std::unique_ptr<sf::Music>);         //puts the music (ptr) in a map.
         sf::Music &GetMusic(std::string fileName);                      //Use getMusic("...").play() to play


### PR DESCRIPTION
Functions Changed:
Audio::Play() -> Audio::PlaySound() 
|---> Reason: To keep it the same between music / sound

Audio::LoadSounds() -> Audio::LoadAudio()
|---> Reason: Clarity.. This function loads/indexes both, Sounds and Music.

Functions Added (check parameters in code):
Audio::PlayMusic();
Audio::StopMusic();
Audio::PauseMusic();

Audio::StopSound()

---

PlayMusic() requires a bool parameter for looping.
It defaults to true. We should check whether LUA can handle that or not.
If it does, we might add it to PlaySound() as well... for flexibilities sake. 
